### PR TITLE
Hotfix: Add crew package to CI environment

### DIFF
--- a/default_ci.nix
+++ b/default_ci.nix
@@ -13,6 +13,7 @@ let
       SummarizedExperiment
       TCGAbiolinks
       # Pipeline
+      crew
       tarchetypes
       targets
       # Core tidyverse


### PR DESCRIPTION
## Summary
Fixes CI failure after PR #14 merge.

## Issue
CI workflow failed with:
```
Error in tar_make():
  there is no package called 'crew'
```

## Fix
Added `crew` package to default_ci.nix

## Testing
- [x] Added crew to package list
- [ ] CI should pass after merge

Failed run: https://github.com/JohnGavin/coMMpass-analysis/actions/runs/21353337411