### PR TITLE
Add ggplot2 support to Shinylive dashboard

### DIFF
--- a/docs/dashboard.html
+++ b/docs/dashboard.html
@@ -130,12 +130,14 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 #| viewerHeight: 800
 
 # Load required packages
+# Using modern Shinylive pattern - packages auto-bundle with dependencies
 library(shiny)
 library(bslib)
 library(plotly)
 library(DT)
 library(dplyr)
 library(tidyr)
+library(ggplot2)  # Now includes munsell automatically via Shinylive 0.8.0+
 library(survival)
 
 # ============================================================================
@@ -1012,7 +1014,11 @@ ui &lt;- page_navbar(
           class = "alert alert-info",
           icon("info-circle"),
           " Start by clicking the ", strong("Data"), " tab and loading the example dataset."
-        )
+        ),
+        hr(),
+        h5("Example ggplot2 Visualization"),
+        p("Demonstrating ggplot2 works in Shinylive with all dependencies:"),
+        plotOutput("example_ggplot", height = "300px")
       )
     )
   ),
@@ -1051,7 +1057,30 @@ server &lt;- function(input, output, session) {
     survival_data = NULL,
     pathway_results = NULL
   )
-  
+
+  # Example ggplot2 visualization showing it works with munsell colors
+  output$example_ggplot &lt;- renderPlot({
+    set.seed(123)
+    data &lt;- data.frame(
+      category = rep(c("High Risk", "Standard Risk", "Low Risk"), each = 100),
+      value = c(rnorm(100, 5, 2), rnorm(100, 7, 1.5), rnorm(100, 9, 1))
+    )
+
+    ggplot(data, aes(x = category, y = value, fill = category)) +
+      geom_violin(alpha = 0.7) +
+      geom_boxplot(width = 0.2, alpha = 0.9) +
+      scale_fill_manual(values = c("High Risk" = "#E63946",
+                                  "Standard Risk" = "#F1C40F",
+                                  "Low Risk" = "#2ECC71")) +
+      theme_minimal() +
+      theme(legend.position = "none",
+            plot.title = element_text(size = 14, face = "bold")) +
+      labs(title = "Risk Stratification Distribution (ggplot2)",
+           x = "Risk Category",
+           y = "Expression Score") +
+      coord_cartesian(ylim = c(0, 12))
+  })
+
   mod_data_loader_server("data_loader", shared_data)
   mod_qc_viz_server("qc_viz", shared_data)
   mod_de_viz_server("de_viz", shared_data)

--- a/vignettes/dashboard_shinylive.qmd
+++ b/vignettes/dashboard_shinylive.qmd
@@ -31,12 +31,14 @@ This is an interactive dashboard for exploring CoMMpass multiple myeloma analysi
 #| viewerHeight: 800
 
 # Load required packages
+# Using modern Shinylive pattern - packages auto-bundle with dependencies
 library(shiny)
 library(bslib)
 library(plotly)
 library(DT)
 library(dplyr)
 library(tidyr)
+library(ggplot2)  # Now includes munsell automatically via Shinylive 0.8.0+
 library(survival)
 
 # ============================================================================
@@ -913,7 +915,11 @@ ui <- page_navbar(
           class = "alert alert-info",
           icon("info-circle"),
           " Start by clicking the ", strong("Data"), " tab and loading the example dataset."
-        )
+        ),
+        hr(),
+        h5("Example ggplot2 Visualization"),
+        p("Demonstrating ggplot2 works in Shinylive with all dependencies:"),
+        plotOutput("example_ggplot", height = "300px")
       )
     )
   ),
@@ -952,7 +958,30 @@ server <- function(input, output, session) {
     survival_data = NULL,
     pathway_results = NULL
   )
-  
+
+  # Example ggplot2 visualization showing it works with munsell colors
+  output$example_ggplot <- renderPlot({
+    set.seed(123)
+    data <- data.frame(
+      category = rep(c("High Risk", "Standard Risk", "Low Risk"), each = 100),
+      value = c(rnorm(100, 5, 2), rnorm(100, 7, 1.5), rnorm(100, 9, 1))
+    )
+
+    ggplot(data, aes(x = category, y = value, fill = category)) +
+      geom_violin(alpha = 0.7) +
+      geom_boxplot(width = 0.2, alpha = 0.9) +
+      scale_fill_manual(values = c("High Risk" = "#E63946",
+                                  "Standard Risk" = "#F1C40F",
+                                  "Low Risk" = "#2ECC71")) +
+      theme_minimal() +
+      theme(legend.position = "none",
+            plot.title = element_text(size = 14, face = "bold")) +
+      labs(title = "Risk Stratification Distribution (ggplot2)",
+           x = "Risk Category",
+           y = "Expression Score") +
+      coord_cartesian(ylim = c(0, 12))
+  })
+
   mod_data_loader_server("data_loader", shared_data)
   mod_qc_viz_server("qc_viz", shared_data)
   mod_de_viz_server("de_viz", shared_data)


### PR DESCRIPTION
## Summary

Adds ggplot2 support to the dashboard using the modern Shinylive pattern documented in the llm repo wiki.

## What Changed

- Added `library(ggplot2)` using simple library call (modern pattern)
- Shinylive 0.8.0+ automatically handles all dependencies including munsell
- Added example ggplot visualization to Overview tab demonstrating it works
- Service worker already correctly configured

## Why This Works

From the documentation (WIKI_SHINYLIVE_LESSONS_LEARNED.md):
- Modern Shinylive detects library() calls and auto-bundles dependencies
- No need for manual webr::mount() or webr::install()
- All transitive dependencies (munsell, colorspace, farver) included automatically

## Testing

The dashboard should now:
- Load without munsell errors
- Display the ggplot violin plot on Overview tab
- Support all ggplot2 visualizations

Live URL: https://johngavin.github.io/coMMpass-analysis/dashboard.html