### PR TITLE
Fix ggplot2/munsell error with explicit webr configuration

### DIFF
--- a/vignettes/dashboard_shinylive.qmd
+++ b/vignettes/dashboard_shinylive.qmd
@@ -9,6 +9,26 @@ format:
     toc-depth: 2
 filters:
   - shinylive
+webr:
+  packages:
+    - shiny
+    - bslib
+    - plotly
+    - DT
+    - dplyr
+    - tidyr
+    - survival
+    - ggplot2
+    # ggplot2 dependencies (CRITICAL - must be explicit!)
+    - munsell
+    - scales
+    - farver
+    - labeling
+    - RColorBrewer
+    - viridisLite
+    - gtable
+    - isoband
+    - colorspace
 ---
 
 ## About This Dashboard


### PR DESCRIPTION
## CRITICAL FIX

The dashboard was failing with the munsell error because the 'automatic bundling' documentation was FALSE.

## Root Cause
WebR does NOT automatically bundle dependencies. You must explicitly declare ALL packages in the YAML front matter.

## Solution
Added `webr:` configuration with all ggplot2 dependencies:
- munsell, scales, farver, labeling
- RColorBrewer, viridisLite, gtable, isoband, colorspace

## Testing
After this fix, the dashboard should load without munsell errors.

## Lessons Documented
Updated AGENTS.md in llm project with critical Shinylive/WebR rules to prevent recurrence.

Fixes: https://johngavin.github.io/coMMpass-analysis/dashboard.html