### PR TITLE
fix(roborev): drop the codex agent pin so reviews inherit a working agent

### DIFF
--- a/.roborev.toml
+++ b/.roborev.toml
@@ -1,4 +1,10 @@
-agent = "codex"
+# No per-repo `agent` pin: inherit the global default_agent (gemini) and
+# default_backup_agent (claude-code). This repo previously pinned
+# agent = "codex" (commit 7801158, 2026-05-13). codex was globally abandoned
+# as a backup in 2026-07 (llm#723, "codex failing 6/6") and its credential
+# now returns HTTP 401 invalid_api_key, so the pin made every review here
+# fail terminally — the repo set no backup_agent, so a codex failure had no
+# fallback. See llm#964.
 review_context_count = 3
 excluded_commit_patterns = ["[skip review]", "docs: rebuild pkgdown", "chore: gitignore"]
 review_reasoning = "standard"


### PR DESCRIPTION
Removes the `agent = "codex"` pin from `.roborev.toml` so reviews in this repo inherit the global default agent.

## Why

The pin was added by `7801158` (2026-05-13) — the last commit made to this repo. Two things happened afterwards that made it harmful:

1. codex was globally abandoned as a backup agent in July (`JohnGavin/llm#723`, *"codex failing 6/6"*). The global config now sets `default_backup_agent = 'claude-code'` precisely so a primary failure recovers.
2. The codex credential now returns `HTTP 401 Unauthorized: Incorrect API key`.

This repo pinned a **primary** agent and set no `backup_agent`, so a codex failure had no fallback at all. Verified on the job rows: `backup_agent` is empty, `agent_invoked = 1`, `retry_count = 3` — three internal retries against a dead credential, then terminal failure.

## Why it mattered beyond this repo

This repo became the fixed point of a starvation loop in `roborev_requeue_dropped.sh` (`JohnGavin/llm#964`). That sweep retries reviews that previously died of provider quota exhaustion, ordered `ORDER BY r.name` with `--limit=5`:

- it was the only repo that could never succeed, so it was the only repo whose pairs stayed eligible for requeue
- `coMMpass` sorts alphabetically first, so it consumed the entire retry budget on every run

Two consecutive real runs, unchanged:

```
09:00:12 candidates=153 enqueued=5 skipped_excluded=87 skipped_unavailable=10 skipped_rate_limit=51 limit=5
13:00:15 candidates=153 enqueued=5 skipped_excluded=87 skipped_unavailable=10 skipped_rate_limit=51 limit=5
```

51 candidates from live repos (`micromort`, `premortem`, `historical`, `crypto_swarms`) skipped at the rate limit both times, and the same five March commits from this repo re-enqueued instead.

## Effect

Reviews here now inherit `default_agent = gemini` with `default_backup_agent = claude-code`. Both pass `roborev check-agents`; codex is the only configured agent currently failing it.

No other setting is changed — `review_context_count`, `excluded_commit_patterns`, the reasoning levels, severity thresholds and `review_guidelines` are all untouched.

## Related

- `JohnGavin/llm#964` — the starvation loop; the script-side fix is separate and does not depend on this
- `JohnGavin/llm#723` — where codex was dropped as a backup
